### PR TITLE
Updated to current version of PCF

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,11 +37,7 @@ Creating service circuit-breaker in org microservices / space fortune-teller as 
 OK
 ----
 
-. In the Pivotal Cloud Foundry App Manager console, click on the *Manage* links for the *Config Server*. Once the service is initialized and the web form appears, paste https://github.com/mstine/config-repo into the *Git URI* field and click *Submit*.
-
-. Also click on the *Manage* links for the *Service Registry* and *Circuit Breaker*. Make sure the services are finished initializing before you proceed.
-
-. Edit the `manifest-pcf.yml` file to specify the Cloud Foundry target the apps are being pushed to, replacing the URL in `CF_TARGET: https://api.cf.deepsouthcloud.com` with the API endpoint for your Cloud Foundry deployment.
+. Edit the `manifest-pcf.yml` file to specify the Cloud Foundry target the apps are being pushed to, replacing the URL in `TRUST_CERTS: https://api.sys.pcf.space` with the API endpoint for your Cloud Foundry deployment.
 
 . Push the microservices:
 

--- a/manifest-pcf.yml
+++ b/manifest-pcf.yml
@@ -1,6 +1,6 @@
 ---
 instances: 1
-memory: 512M
+memory: 768M
 applications:
 - name: fortune-service
   host: fortunes
@@ -18,4 +18,4 @@ applications:
   - circuit-breaker
 env:
   SPRING_PROFILES_ACTIVE: pcf
-  CF_TARGET: https://api.cf.deepsouth.com
+  TRUST_CERTS: api.sys.pcf.space

--- a/scripts/create_services_pcf.sh
+++ b/scripts/create_services_pcf.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cf cs p-mysql 100mb-dev fortunes-db
-cf cs p-config-server standard config-service
+cf cs p-mysql 100mb fortunes-db
+cf cs p-config-server standard config-service -c '{ "git": { "uri": "https://github.com/mstine/config-repo" }}' 
 cf cs p-service-registry standard service-registry
 cf cs p-circuit-breaker-dashboard standard circuit-breaker


### PR DESCRIPTION
Revised instructions to reflect changes in how SCS services are deployed
Updated the memory to 768M (512M fails with the JBP 4.0)
Changed create_services_pcf to reflect PCF service names and add git config
